### PR TITLE
Adventure view

### DIFF
--- a/app/src/main/java/com/example/active_portfolio_mobile/composables/adventure/AdventureView.kt
+++ b/app/src/main/java/com/example/active_portfolio_mobile/composables/adventure/AdventureView.kt
@@ -1,0 +1,49 @@
+package com.example.active_portfolio_mobile.composables.adventure
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.material3.Card
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.ui.Modifier
+import androidx.lifecycle.viewmodel.compose.viewModel
+import com.example.active_portfolio_mobile.data.remote.dto.Adventure
+import com.example.active_portfolio_mobile.data.remote.dto.SectionType
+import com.example.active_portfolio_mobile.viewModels.AdventureSectionUpdateVM
+
+/**
+ * A view of an adventure with its sections.
+ * Sections which are shown can be optionally filtered by portfolio.
+ * @param adventureToView the adventure to be viewed... Shocker, I know.
+ * @param modifier the modifier to be applied to the view.
+ * @param filterPortfolioId the id of the portfolio by which sections will be filtered.
+ * Only sections included in the portfolio will appear. Leaving this empty will show all sections.
+ */
+@Composable
+fun AdventureView(
+    adventureToView: Adventure,
+    modifier: Modifier = Modifier,
+    filterPortfolioId: String = "",
+    adventureSectionVM: AdventureSectionUpdateVM = viewModel()
+) {
+    LaunchedEffect(adventureToView) {
+        adventureSectionVM.fetchSections(adventureToView.id, filterPortfolioId)
+    }
+    val sections = adventureSectionVM.sections
+
+    Card(modifier = modifier) {
+        Column {
+            Text(adventureToView.title)
+
+            sections.value.forEach { section ->
+                DropDownTab(section.label) {
+                    when(section.type) {
+                        SectionType.TEXT -> TextSectionView(section)
+                        SectionType.LINK -> LinkSectionView(section)
+                        SectionType.IMAGE -> ImageSectionView(section)
+                    }
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/example/active_portfolio_mobile/composables/adventure/SectionView.kt
+++ b/app/src/main/java/com/example/active_portfolio_mobile/composables/adventure/SectionView.kt
@@ -1,0 +1,84 @@
+package com.example.active_portfolio_mobile.composables.adventure
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.width
+import androidx.compose.material3.Card
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Text
+import androidx.compose.material3.carousel.HorizontalCenteredHeroCarousel
+import androidx.compose.material3.carousel.rememberCarouselState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.asImageBitmap
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.lifecycle.viewmodel.compose.viewModel
+import com.example.active_portfolio_mobile.data.remote.dto.AdventureSection
+import com.example.active_portfolio_mobile.viewModels.AdventureSectionImageUpdateVM
+
+/**
+ * A view for displaying an Adventure Section of type "text".
+ * @param section the section to be shown.
+ */
+@Composable
+fun TextSectionView(section: AdventureSection) {
+    Card {
+        Text(section.content)
+    }
+}
+
+/**
+ * A view for displaying an Adventure Section of type "link".
+ * @param section the section to be shown.
+ */
+@Composable
+fun LinkSectionView(section: AdventureSection) {
+    Column {
+        Card {
+            Text(section.content)
+        }
+        if (section.description != null) {
+            Card {
+                Text(section.description)
+            }
+        }
+    }
+}
+
+/**
+ * A view for displaying an Adventure Section of type "image".
+ * @param section the section to be shown.
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun ImageSectionView(
+    section: AdventureSection,
+    imageSectionVM: AdventureSectionImageUpdateVM = viewModel()
+) {
+    LaunchedEffect(Unit) {
+        imageSectionVM.setSection(section)
+    }
+    val bitmaps = imageSectionVM.bitmapImages.collectAsStateWithLifecycle()
+    val carouselState = rememberCarouselState { bitmaps.value.size }
+
+    Column {
+        HorizontalCenteredHeroCarousel(
+            state = carouselState,
+            itemSpacing = 10.dp
+        ) { index ->
+            Image(
+                bitmap = bitmaps.value[index].asImageBitmap(),
+                contentDescription = null,
+                modifier = Modifier.width(300.dp).height(200.dp)
+            )
+        }
+        if (section.description != null) {
+            Card {
+                Text(section.description)
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/example/active_portfolio_mobile/viewModels/AdventureSectionUpdateVM.kt
+++ b/app/src/main/java/com/example/active_portfolio_mobile/viewModels/AdventureSectionUpdateVM.kt
@@ -41,11 +41,12 @@ class AdventureSectionUpdateVM : ViewModel() {
 
     var sections = mutableStateOf<List<AdventureSection>>(emptyList())
         private set
-    fun fetchSections(adventureId: String) {
+    fun fetchSections(adventureId: String, filterPortfolioId: String = "") {
         viewModelScope.launch {
             try {
                 val response = ActivePortfolioApi.adventureSection.getSectionsOfAdventure(
-                    adventureId = adventureId
+                    adventureId = adventureId,
+                    filterPortfolio = filterPortfolioId
                 )
                 if (response.isSuccessful) {
                     sections.value = response.body() ?: emptyList()


### PR DESCRIPTION
Added a view for adventures which takes as a parameter an adventure to view and an optional portfolio id for filtering the sections to be displayed.
Added views for individual sections. There is one view per section type (text, link, or image). Section views are loaded dynamically into the adventure view, retrieved through an API call to our backend server.