### PR TITLE
Adventure list view and Adventure View Screen

### DIFF
--- a/app/src/main/java/com/example/active_portfolio_mobile/Screen/adventure/AdventureViewScreen.kt
+++ b/app/src/main/java/com/example/active_portfolio_mobile/Screen/adventure/AdventureViewScreen.kt
@@ -1,0 +1,30 @@
+package com.example.active_portfolio_mobile.Screen.adventure
+
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.lifecycle.viewmodel.compose.viewModel
+import com.example.active_portfolio_mobile.composables.adventure.AdventureView
+import com.example.active_portfolio_mobile.layouts.MainLayout
+import com.example.active_portfolio_mobile.viewModels.AdventureCreationUpdateVM
+
+/**
+ * A screen which allows for the viewing of an individual Adventure.
+ * @param adventureId the id of the adventure to be viewed on the screen.
+ */
+@Composable
+fun AdventureViewScreen(adventureId: String, adventureVM: AdventureCreationUpdateVM = viewModel()) {
+    LaunchedEffect(Unit) {
+        adventureVM.setAdventure(adventureId)
+    }
+    val adventure = adventureVM.adventure.collectAsStateWithLifecycle()
+
+    MainLayout {
+        LazyColumn {
+            item {
+                AdventureView(adventure.value)
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/example/active_portfolio_mobile/composables/adventure/AdvenureNavigationList.kt
+++ b/app/src/main/java/com/example/active_portfolio_mobile/composables/adventure/AdvenureNavigationList.kt
@@ -18,6 +18,13 @@ import com.example.active_portfolio_mobile.navigation.Routes
 import com.example.active_portfolio_mobile.utilities.canViewWithRole
 import com.example.active_portfolio_mobile.viewModels.AdventureVM
 
+/**
+ * A list of buttons for navigating to the view and update pages of a specified user's adventures.
+ * The adventures which appear are based on the signed in user's role compared to the adventure's
+ * visibility level. The button to navigate to the update page is only accessible by the
+ * adventure's creator and admin users.
+ * @param userId the id of the user whose created adventures are to be listed.
+ */
 @Composable
 fun AdventureNavigationList(
     userId: String,

--- a/app/src/main/java/com/example/active_portfolio_mobile/composables/adventure/AdvenureNavigationList.kt
+++ b/app/src/main/java/com/example/active_portfolio_mobile/composables/adventure/AdvenureNavigationList.kt
@@ -1,0 +1,62 @@
+package com.example.active_portfolio_mobile.composables.adventure
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.width
+import androidx.compose.material3.Button
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.lifecycle.viewmodel.compose.viewModel
+import com.example.active_portfolio_mobile.navigation.LocalAuthViewModel
+import com.example.active_portfolio_mobile.navigation.LocalNavController
+import com.example.active_portfolio_mobile.navigation.Routes
+import com.example.active_portfolio_mobile.utilities.canViewWithRole
+import com.example.active_portfolio_mobile.viewModels.AdventureVM
+
+@Composable
+fun AdventureNavigationList(
+    userId: String,
+    adventureVM: AdventureVM = viewModel()
+) {
+    LaunchedEffect(Unit) {
+        adventureVM.fetchAdventuresByUser(userId)
+    }
+    val adventures = adventureVM.adventures.collectAsStateWithLifecycle()
+    val navController = LocalNavController.current
+    val authViewModel = LocalAuthViewModel.current
+    val userAuthState = authViewModel.uiState.collectAsStateWithLifecycle().value
+
+    Column {
+        adventures.value.forEach { adventure ->
+            // Only display adventures if the signed in user is their creator,
+            // or if they have the right role for the adventure's visibility level.
+            if ( userAuthState.user?.id == adventure.userId
+                || canViewWithRole(userAuthState.user?.role ?: "public", adventure.visibility)
+                ) {
+                Row {
+                    Button(
+                        modifier = Modifier.width(200.dp),
+                        onClick = {
+                        navController.navigate(Routes.AdventureView.go(adventure.id))
+                    }) {
+                        Text(adventure.title, maxLines = 1, overflow = TextOverflow.Ellipsis)
+                    }
+                    // Only provide the "Update" button if the signed in user is the adventure's
+                    // creator or if they are an admin.
+                    if (userAuthState.user?.id == userId || userAuthState.user?.role == "admin") {
+                        Button(onClick = {
+                            navController.navigate(Routes.AdventureUpdate.go(adventure.id))
+                        }) {
+                            Text("Update")
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/example/active_portfolio_mobile/data/remote/network/AdventureService.kt
+++ b/app/src/main/java/com/example/active_portfolio_mobile/data/remote/network/AdventureService.kt
@@ -16,8 +16,14 @@ interface AdventureService {
     suspend fun getOne(
         @Path("id") id: String
     ) : Response<Adventure>
+
     @GET("adventures/all")
     suspend fun getAll() : Response<List<Adventure>>
+
+    @GET("adventures/allByUser/{userId}")
+    suspend fun getAllByUser(
+        @Path("userId") userId: String
+    ) : Response<List<Adventure>>
 
     @POST("adventures")
     suspend fun create(@Body adventureToCreate: Adventure) : Response<Adventure>

--- a/app/src/main/java/com/example/active_portfolio_mobile/navigation/Router.kt
+++ b/app/src/main/java/com/example/active_portfolio_mobile/navigation/Router.kt
@@ -16,6 +16,7 @@ import androidx.navigation.compose.rememberNavController
 import com.example.active_portfolio_mobile.Screen.CommentPage
 import com.example.active_portfolio_mobile.Screen.AboutUsPage
 import com.example.active_portfolio_mobile.Screen.LandingPage
+import com.example.active_portfolio_mobile.Screen.adventure.AdventureViewScreen
 import com.example.active_portfolio_mobile.Screen.adventure.CreateAdventureScreen
 import com.example.active_portfolio_mobile.Screen.adventure.UpdateSectionsScreen
 import com.example.active_portfolio_mobile.ui.profile.ProfilePage
@@ -46,6 +47,18 @@ fun Router(modifier: Modifier) {
             composable(Routes.About.route) {AboutUsPage(modifier)}
             // Adventure routes
             composable(Routes.AdventureCreate.route) { CreateAdventureScreen(modifier) }
+            composable(Routes.AdventureUpdate.route) {
+                val id = it.arguments?.getString("adventureId")
+                if (id != null) {
+                    CreateAdventureScreen(modifier, id)
+                }
+            }
+            composable(Routes.AdventureView.route) {
+                val id = it.arguments?.getString("adventureId")
+                if (id != null) {
+                    AdventureViewScreen(id)
+                }
+            }
             composable(Routes.SectionsUpdate.route) {
                 val id = it.arguments?.getString("adventureId")
                 if (id != null) {

--- a/app/src/main/java/com/example/active_portfolio_mobile/navigation/Router.kt
+++ b/app/src/main/java/com/example/active_portfolio_mobile/navigation/Router.kt
@@ -29,6 +29,7 @@ import com.example.active_portfolio_mobile.ui.auth.SignUpPage
 //Sets up the app navigation using NavHost with three routes: LandingPage,
 // CommentPage and AboutUsPage.
 val LocalNavController = compositionLocalOf<NavController> { error("No NavController found!") }
+val LocalAuthViewModel = compositionLocalOf<AuthViewModel> { error("No UserViewModel provided") }
 @Composable
 fun Router(modifier: Modifier) {
     val navController = rememberNavController()
@@ -38,63 +39,69 @@ fun Router(modifier: Modifier) {
     val authViewModel: AuthViewModel = viewModel(
         factory = ViewModelFactory(tokenManager)
     )
-
-    CompositionLocalProvider(
-        LocalNavController provides navController) {
-        NavHost(navController = navController, startDestination = Routes.Main.route, modifier = modifier.fillMaxSize()) {
-            composable(Routes.Main.route) { LandingPage(modifier)}
-            composable(Routes.Comment.route) {CommentPage(modifier)}
-            composable(Routes.About.route) {AboutUsPage(modifier)}
-            // Adventure routes
-            composable(Routes.AdventureCreate.route) { CreateAdventureScreen(modifier) }
-            composable(Routes.AdventureUpdate.route) {
-                val id = it.arguments?.getString("adventureId")
-                if (id != null) {
-                    CreateAdventureScreen(modifier, id)
-                }
-            }
-            composable(Routes.AdventureView.route) {
-                val id = it.arguments?.getString("adventureId")
-                if (id != null) {
-                    AdventureViewScreen(id)
-                }
-            }
-            composable(Routes.SectionsUpdate.route) {
-                val id = it.arguments?.getString("adventureId")
-                if (id != null) {
-                    UpdateSectionsScreen(id)
-                }
-            }
-
-            // Auth
-            composable(Routes.Login.route) {
-                LoginPage(
-                    authViewModel,
-                    onNavigateToSignUp = {navController.navigate(Routes.SignUp.route)},
-                    onLoginSuccess = {
-                        navController.navigate(Routes.Profile.route){
-                            popUpTo(Routes.Login.route) {inclusive = true}
-                            launchSingleTop = true
-                        }
+    CompositionLocalProvider(LocalAuthViewModel provides authViewModel) {
+        CompositionLocalProvider(
+            LocalNavController provides navController
+        ) {
+            NavHost(
+                navController = navController,
+                startDestination = Routes.Main.route,
+                modifier = modifier.fillMaxSize()
+            ) {
+                composable(Routes.Main.route) { LandingPage(modifier) }
+                composable(Routes.Comment.route) { CommentPage(modifier) }
+                composable(Routes.About.route) { AboutUsPage(modifier) }
+                // Adventure routes
+                composable(Routes.AdventureCreate.route) { CreateAdventureScreen(modifier) }
+                composable(Routes.AdventureUpdate.route) {
+                    val id = it.arguments?.getString("adventureId")
+                    if (id != null) {
+                        CreateAdventureScreen(modifier, id)
                     }
-                )
-            }
-            composable (Routes.SignUp.route){
-                SignUpPage(
-                    authViewModel,
-                    onNavigateToLogin = {navController.navigate(Routes.Login.route)},
-                    onSignUpSuccess = {
-                        navController.navigate(Routes.Main.route){
-                            popUpTo(Routes.SignUp.route) {inclusive = true}
-                            launchSingleTop = true
-                        }
+                }
+                composable(Routes.AdventureView.route) {
+                    val id = it.arguments?.getString("adventureId")
+                    if (id != null) {
+                        AdventureViewScreen(id)
                     }
-                )
-            }
+                }
+                composable(Routes.SectionsUpdate.route) {
+                    val id = it.arguments?.getString("adventureId")
+                    if (id != null) {
+                        UpdateSectionsScreen(id)
+                    }
+                }
 
-            // profile
-            composable(Routes.Profile.route) {
-                ProfilePage(authViewModel)
+                // Auth
+                composable(Routes.Login.route) {
+                    LoginPage(
+                        authViewModel,
+                        onNavigateToSignUp = { navController.navigate(Routes.SignUp.route) },
+                        onLoginSuccess = {
+                            navController.navigate(Routes.Profile.route) {
+                                popUpTo(Routes.Login.route) { inclusive = true }
+                                launchSingleTop = true
+                            }
+                        }
+                    )
+                }
+                composable(Routes.SignUp.route) {
+                    SignUpPage(
+                        authViewModel,
+                        onNavigateToLogin = { navController.navigate(Routes.Login.route) },
+                        onSignUpSuccess = {
+                            navController.navigate(Routes.Main.route) {
+                                popUpTo(Routes.SignUp.route) { inclusive = true }
+                                launchSingleTop = true
+                            }
+                        }
+                    )
+                }
+
+                // profile
+                composable(Routes.Profile.route) {
+                    ProfilePage(authViewModel)
+                }
             }
         }
     }

--- a/app/src/main/java/com/example/active_portfolio_mobile/navigation/Routes.kt
+++ b/app/src/main/java/com/example/active_portfolio_mobile/navigation/Routes.kt
@@ -6,7 +6,15 @@ sealed class Routes(val route: String){
     object Main : Routes("LandingPageRoute")
     object Comment : Routes("CommentPageRoute")
     object About: Routes("AboutUsRoute")
+
+    // Adventures
     object AdventureCreate: Routes("AdventureCreateRoute")
+    object AdventureUpdate: Routes("AdventureUpdateRoute/{adventureId}") {
+        fun go(adventureId: String) = "AdventureUpdateRoute/$adventureId"
+    }
+    object AdventureView: Routes("AdventureViewRoute/{adventureId}") {
+        fun go(adventureId: String) = "AdventureViewRoute/$adventureId"
+    }
     object SectionsUpdate: Routes("SectionsUpdateRoute/{adventureId}") {
         fun go(adventureId: String) = "SectionsUpdateRoute/$adventureId"
     }

--- a/app/src/main/java/com/example/active_portfolio_mobile/utilities/CanViewWithRole.kt
+++ b/app/src/main/java/com/example/active_portfolio_mobile/utilities/CanViewWithRole.kt
@@ -1,0 +1,20 @@
+package com.example.active_portfolio_mobile.utilities
+
+/**
+ * A utility function for determining whether a user has the correct role to view something with
+ * a certain visibility level. Note that this function assumes the user is not the item's creator.
+ * It should therefore be used in conjunction with other checks, especially with items assigned
+ * as private.
+ * @param userRole The role of the user to be checked.
+ * @param visibility The visibility level for the user role to be checked against.
+ */
+fun canViewWithRole(userRole: String, visibility: String) : Boolean {
+    return when (userRole.lowercase()) {
+        "admin" -> true
+        "cs_community" -> visibility.lowercase() != "private"
+        "student" -> visibility.lowercase() !in listOf("private", "cs")
+        "teacher" -> visibility.lowercase() !in listOf("private", "cs")
+        "public" -> visibility.lowercase() == "public"
+        else -> false
+    }
+}

--- a/app/src/main/java/com/example/active_portfolio_mobile/viewModels/AdventureVM.kt
+++ b/app/src/main/java/com/example/active_portfolio_mobile/viewModels/AdventureVM.kt
@@ -25,4 +25,19 @@ class AdventureVM : ViewModel() {
             }
         }
     }
+
+    fun fetchAdventuresByUser(userId: String) {
+        viewModelScope.launch {
+            try {
+                val response = ActivePortfolioApi.adventure.getAllByUser(userId)
+                if (response.isSuccessful) {
+                    _adventures.value = response.body() ?: emptyList()
+                } else {
+                    println(response.errorBody().toString())
+                }
+            } catch(err: Exception) {
+                println("An error occurred when fetching all Adventures by user: $err")
+            }
+        }
+    }
 }


### PR DESCRIPTION
There is now a dedicated screen for viewing the existing Adventure View composable, as well as a navigation route to get to it.

Created a list which takes a userId and displays buttons to navigate to the view screen of each of their adventures.
The Adventures which are shown is determined by the role of the signed-in user compared to the visibility level of that adventure.
Admin users and the user who created the adventures also see a button which can navigate to the adventure's update screen.