### PR TITLE
Adventures gated access

### DIFF
--- a/app/src/main/java/com/example/active_portfolio_mobile/Screen/adventure/CreateAdventureScreen.kt
+++ b/app/src/main/java/com/example/active_portfolio_mobile/Screen/adventure/CreateAdventureScreen.kt
@@ -104,7 +104,7 @@ fun CreateAdventureScreen(
             // Create Adventure or save changes to existing one.
             item {
                 Button(onClick = {
-                    adventureVM.saveAdventure()
+                    adventureVM.saveAdventure(authViewModel.tokenManager.getToken())
                 }) {
                     Text("Save")
                 }
@@ -116,7 +116,7 @@ fun CreateAdventureScreen(
             item {
                 if (adventure.id != "") {
                     DeleteButtonWithConfirm {
-                        adventureVM.deleteAdventure()
+                        adventureVM.deleteAdventure(authViewModel.tokenManager.getToken())
                     }
                 }
             }

--- a/app/src/main/java/com/example/active_portfolio_mobile/composables/adventure/AdvenureNavigationList.kt
+++ b/app/src/main/java/com/example/active_portfolio_mobile/composables/adventure/AdvenureNavigationList.kt
@@ -1,13 +1,27 @@
 package com.example.active_portfolio_mobile.composables.adventure
 
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Source
 import androidx.compose.material3.Button
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
@@ -38,28 +52,83 @@ fun AdventureNavigationList(
     val authViewModel = LocalAuthViewModel.current
     val userAuthState = authViewModel.uiState.collectAsStateWithLifecycle().value
 
-    Column {
-        adventures.value.forEach { adventure ->
-            // Only display adventures if the signed in user is their creator,
-            // or if they have the right role for the adventure's visibility level.
-            if ( userAuthState.user?.id == adventure.userId
-                || canViewWithRole(userAuthState.user?.role ?: "public", adventure.visibility)
+    Column (
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(16.dp),
+        verticalArrangement = Arrangement.spacedBy(12.dp)
+    ){
+        // =============== Header ===============
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically
+        ){
+            Text(
+                text = "My Adventure",
+                style = MaterialTheme.typography.titleLarge,
+                fontWeight = FontWeight.Bold
+            )
+            Text(
+                text = "${adventures.value.size}",
+                style = MaterialTheme.typography.titleMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+        }
+
+        Spacer(modifier = Modifier.height(4.dp))
+
+        // =============== Adventure list ===============
+        if (adventures.value.isEmpty()){
+            Card(
+                modifier = Modifier.fillMaxWidth(),
+                colors = CardDefaults.cardColors(
+                    containerColor = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.3f)
+                )
+            ) {
+                Column(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(32.dp),
                 ) {
-                Row {
-                    Button(
-                        modifier = Modifier.width(200.dp),
-                        onClick = {
-                        navController.navigate(Routes.AdventureView.go(adventure.id))
-                    }) {
-                        Text(adventure.title, maxLines = 1, overflow = TextOverflow.Ellipsis)
-                    }
-                    // Only provide the "Update" button if the signed in user is the adventure's
-                    // creator or if they are an admin.
-                    if (userAuthState.user?.id == userId || userAuthState.user?.role == "admin") {
-                        Button(onClick = {
-                            navController.navigate(Routes.AdventureUpdate.go(adventure.id))
-                        }) {
-                            Text("Update")
+                    Icon(
+                        imageVector = Icons.Default.Source,
+                        contentDescription = null,
+                        modifier = Modifier.size(48.dp),
+                        tint = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                    Spacer(modifier = Modifier.height(16.dp))
+
+                    Text(
+                        text = "No Adventures Yet",
+                        style = MaterialTheme.typography.titleMedium,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                }
+            }
+        } else{
+            adventures.value.forEach { adventure ->
+                // Only display adventures if the signed in user is their creator,
+                // or if they have the right role for the adventure's visibility level.
+                if ( userAuthState.user?.id == adventure.userId
+                    || canViewWithRole(userAuthState.user?.role ?: "public", adventure.visibility)
+                ) {
+                    Row {
+                        Button(
+                            modifier = Modifier.width(200.dp),
+                            onClick = {
+                                navController.navigate(Routes.AdventureView.go(adventure.id))
+                            }) {
+                            Text(adventure.title, maxLines = 1, overflow = TextOverflow.Ellipsis)
+                        }
+                        // Only provide the "Update" button if the signed in user is the adventure's
+                        // creator or if they are an admin.
+                        if (userAuthState.user?.id == userId || userAuthState.user?.role == "admin") {
+                            Button(onClick = {
+                                navController.navigate(Routes.AdventureUpdate.go(adventure.id))
+                            }) {
+                                Text("Update")
+                            }
                         }
                     }
                 }

--- a/app/src/main/java/com/example/active_portfolio_mobile/composables/adventure/CreateSectionForm.kt
+++ b/app/src/main/java/com/example/active_portfolio_mobile/composables/adventure/CreateSectionForm.kt
@@ -23,6 +23,7 @@ import androidx.compose.ui.unit.dp
 import androidx.navigation.NavController
 import com.example.active_portfolio_mobile.data.remote.dto.AdventureSection
 import com.example.active_portfolio_mobile.data.remote.dto.SectionType
+import com.example.active_portfolio_mobile.navigation.LocalAuthViewModel
 import com.example.active_portfolio_mobile.navigation.LocalNavController
 import com.example.active_portfolio_mobile.utilities.rememberMutableStateListOf
 import com.example.active_portfolio_mobile.viewModels.AdventureSectionCreationVM
@@ -42,6 +43,7 @@ fun CreateSectionForm(type: String, sectionVM: AdventureSectionCreationVM) {
     val portfolios = rememberMutableStateListOf<String>()
     val navController: NavController = LocalNavController.current
     val parentPortfolios = sectionVM.portfolios
+    val authViewModel = LocalAuthViewModel.current
 
     Column {
         // Create the Section's label.
@@ -119,12 +121,16 @@ fun CreateSectionForm(type: String, sectionVM: AdventureSectionCreationVM) {
             // Save the section according to its type.
             when (type) {
                 SectionType.IMAGE -> sectionVM.saveNewImageSection(
-                    sectionToSave, 
-                    imageContent
+                    token = authViewModel.tokenManager.getToken(),
+                    sectionToSave = sectionToSave,
+                    images = imageContent
                 ){
                     success = it
                 }
-                else -> sectionVM.saveNewSection(sectionToSave) {
+                else -> sectionVM.saveNewSection(
+                    token = authViewModel.tokenManager.getToken(),
+                    sectionToSave = sectionToSave
+                ) {
                     success = it
                 }
             }

--- a/app/src/main/java/com/example/active_portfolio_mobile/composables/adventure/UpdateSectionForm.kt
+++ b/app/src/main/java/com/example/active_portfolio_mobile/composables/adventure/UpdateSectionForm.kt
@@ -28,6 +28,7 @@ import com.example.active_portfolio_mobile.data.remote.dto.Adventure
 import com.example.active_portfolio_mobile.data.remote.dto.AdventureSection
 import com.example.active_portfolio_mobile.data.remote.dto.SectionType
 import com.example.active_portfolio_mobile.data.remote.network.ActivePortfolioApi.adventure
+import com.example.active_portfolio_mobile.navigation.LocalAuthViewModel
 import com.example.active_portfolio_mobile.viewModels.AdventureSectionImageUpdateVM
 import com.example.active_portfolio_mobile.viewModels.AdventureSectionUpdateVM
 
@@ -45,6 +46,7 @@ fun UpdateSectionForm(
     val parentPortfolios = adventureSectionVM.portfolios
     val section = remember { mutableStateOf(sectionToShow) }
     var message by rememberSaveable { mutableStateOf("") }
+    val authViewModel = LocalAuthViewModel.current
 
     Column {
         TextField(
@@ -96,7 +98,10 @@ fun UpdateSectionForm(
         }
 
         Button(onClick = {
-            adventureSectionVM.updateSection(section.value) { newMessage ->
+            adventureSectionVM.updateSection(
+                section.value,
+                authViewModel.tokenManager.getToken()
+            ) { newMessage ->
                 message = newMessage
                 println(message)
             }
@@ -105,7 +110,10 @@ fun UpdateSectionForm(
         }
 
         DeleteButtonWithConfirm {
-            adventureSectionVM.deleteSection(section.value) {
+            adventureSectionVM.deleteSection(
+                section.value,
+                authViewModel.tokenManager.getToken()
+            ) {
                 message = it
             }
         }
@@ -157,6 +165,7 @@ fun UpdateImageSectionForm(
     val section by adventureSectionVM.section.collectAsStateWithLifecycle()
     val bitmaps = adventureSectionVM.bitmapImages.collectAsStateWithLifecycle()
     var message by rememberSaveable { mutableStateOf("") }
+    val authViewModel = LocalAuthViewModel.current
 
     Column {
         TextField(
@@ -202,7 +211,9 @@ fun UpdateImageSectionForm(
         }
 
         Button(onClick = {
-            adventureSectionVM.updateSection { newMessage ->
+            adventureSectionVM.updateSection(
+                authViewModel.tokenManager.getToken()
+            ) { newMessage ->
                 message = newMessage
                 println(message)
             }
@@ -211,7 +222,10 @@ fun UpdateImageSectionForm(
         }
 
         DeleteButtonWithConfirm {
-            allSectionsVM.deleteSection(section) {
+            allSectionsVM.deleteSection(
+                section = section,
+                token = authViewModel.tokenManager.getToken()
+            ) {
                 message = it
             }
             if (message == "Success") {  }

--- a/app/src/main/java/com/example/active_portfolio_mobile/data/remote/network/ActivePortfolioApiService.kt
+++ b/app/src/main/java/com/example/active_portfolio_mobile/data/remote/network/ActivePortfolioApiService.kt
@@ -1,7 +1,5 @@
 package com.example.active_portfolio_mobile.data.remote.network
 
-import com.example.active_portfolio_mobile.data.remote.network.AdventureSectionService
-import com.example.active_portfolio_mobile.data.remote.network.AdventureService
 import com.jakewharton.retrofit2.converter.kotlinx.serialization.asConverterFactory
 import kotlinx.serialization.json.Json
 import okhttp3.MediaType.Companion.toMediaType
@@ -14,7 +12,7 @@ private val json = Json {
     coerceInputValues = true
 }
 
-private const val BASE_URL = "https://activeportfolio.onrender.com/"
+private const val BASE_URL = "http://10.0.2.2:1339/"
 
 private val retrofit = Retrofit.Builder()
     .addConverterFactory(json.asConverterFactory("application/json".toMediaType()))

--- a/app/src/main/java/com/example/active_portfolio_mobile/data/remote/network/ActivePortfolioApiService.kt
+++ b/app/src/main/java/com/example/active_portfolio_mobile/data/remote/network/ActivePortfolioApiService.kt
@@ -12,7 +12,7 @@ private val json = Json {
     coerceInputValues = true
 }
 
-private const val BASE_URL = "http://10.0.2.2:1339/"
+private const val BASE_URL = "https://activeportfolio.onrender.com/"
 
 private val retrofit = Retrofit.Builder()
     .addConverterFactory(json.asConverterFactory("application/json".toMediaType()))

--- a/app/src/main/java/com/example/active_portfolio_mobile/data/remote/network/AdventureSectionService.kt
+++ b/app/src/main/java/com/example/active_portfolio_mobile/data/remote/network/AdventureSectionService.kt
@@ -9,6 +9,7 @@ import retrofit2.Response
 import retrofit2.http.Body
 import retrofit2.http.DELETE
 import retrofit2.http.GET
+import retrofit2.http.Header
 import retrofit2.http.Multipart
 import retrofit2.http.POST
 import retrofit2.http.PUT
@@ -25,12 +26,14 @@ interface AdventureSectionService {
 
     @POST("sections")
     suspend fun createSection(
+        @Header("Authorization") token: String,
         @Body sectionToCreate: AdventureSectionCreationRequest
     ): Response<String>
 
     @Multipart
     @POST("sections")
     suspend fun createImageSection(
+        @Header("Authorization") token: String,
         @Part("label") label: RequestBody,
         @Part("description") description: RequestBody,
         @Part("type") type: RequestBody,
@@ -41,6 +44,7 @@ interface AdventureSectionService {
     @PUT("sections/{id}")
     suspend fun updateSection(
         @Path("id") sectionId: String,
+        @Header("Authorization") token: String,
         @Body updatedSection: AdventureSectionUpdateRequest
     ): Response<String>
 
@@ -48,6 +52,7 @@ interface AdventureSectionService {
     @PUT("sections/{id}")
     suspend fun updateImageSection(
         @Path("id") id: String,
+        @Header("Authorization") token: String,
         @Part("newLabel") label: RequestBody,
         @Part("newDescription") description: RequestBody,
         @Part newContentFiles: List<MultipartBody.Part>
@@ -55,6 +60,7 @@ interface AdventureSectionService {
 
     @DELETE("sections/{id}")
     suspend fun delete(
+        @Header("Authorization") token: String,
         @Path("id") id: String
     ) : Response<AdventureSection>
 }

--- a/app/src/main/java/com/example/active_portfolio_mobile/data/remote/network/AdventureService.kt
+++ b/app/src/main/java/com/example/active_portfolio_mobile/data/remote/network/AdventureService.kt
@@ -7,6 +7,7 @@ import retrofit2.Response
 import retrofit2.http.Body
 import retrofit2.http.DELETE
 import retrofit2.http.GET
+import retrofit2.http.Header
 import retrofit2.http.POST
 import retrofit2.http.PUT
 import retrofit2.http.Path
@@ -26,16 +27,21 @@ interface AdventureService {
     ) : Response<List<Adventure>>
 
     @POST("adventures")
-    suspend fun create(@Body adventureToCreate: Adventure) : Response<Adventure>
+    suspend fun create(
+        @Header("Authorization") token: String,
+        @Body adventureToCreate: Adventure
+    ) : Response<Adventure>
 
     @PUT("adventures/{id}")
     suspend fun update(
         @Path("id") id: String,
+        @Header("Authorization") token: String,
         @Body updatedAdventure: AdventureUpdateRequest
     ) : Response<Adventure>
 
     @DELETE("adventures/{id}")
     suspend fun delete(
+        @Header("Authorization") token: String,
         @Path("id") id: String
     ) : Response<DeleteAdventureResponseBody>
 }

--- a/app/src/main/java/com/example/active_portfolio_mobile/ui/auth/AuthViewModel.kt
+++ b/app/src/main/java/com/example/active_portfolio_mobile/ui/auth/AuthViewModel.kt
@@ -42,7 +42,7 @@ data class AuthUiState(
  */
 
 class AuthViewModel(
-    private val tokenManager: TokenManager
+    val tokenManager: TokenManager
 ) : ViewModel() {
 
     // Retrofit API service for backend communication

--- a/app/src/main/java/com/example/active_portfolio_mobile/ui/common/MainLayout.kt
+++ b/app/src/main/java/com/example/active_portfolio_mobile/ui/common/MainLayout.kt
@@ -24,6 +24,8 @@ import androidx.compose.material.icons.filled.Home
 import androidx.compose.material.icons.filled.Person
 import androidx.compose.material3.BottomAppBar
 import androidx.compose.material3.Button
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.example.active_portfolio_mobile.navigation.LocalAuthViewModel
 import com.example.active_portfolio_mobile.navigation.Routes
 
 /**
@@ -34,6 +36,7 @@ import com.example.active_portfolio_mobile.navigation.Routes
 @Composable
 fun MainLayout(content: @Composable () -> Unit) {
     val navController = LocalNavController.current
+    val user = LocalAuthViewModel.current.uiState.collectAsStateWithLifecycle()
 
     Scaffold(
         topBar = {
@@ -63,6 +66,7 @@ fun MainLayout(content: @Composable () -> Unit) {
                 modifier = Modifier.fillMaxWidth(),
                 actions = {
                     Row (modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.SpaceEvenly) {
+                        // Navigate home button.
                         IconButton(onClick = {
                             navController.navigate(route = Routes.Main.route)
                         }) {
@@ -71,14 +75,20 @@ fun MainLayout(content: @Composable () -> Unit) {
                                 contentDescription = "Home"
                             )
                         }
+                        // Create Adventure or Portfolio button.
                         IconButton( onClick = {
-                            navController.navigate(Routes.Create.route)
+                            if (user.value.isLoggedIn) {
+                                navController.navigate(Routes.Create.route)
+                            } else {
+                                navController.navigate(Routes.Login.route)
+                            }
                         }) {
                             Icon(
                                 imageVector = Icons.Filled.Add,
                                 contentDescription = "Create a new Adventure or Portfolio"
                             )
                         }
+                        // Navigate to profile page.
                         IconButton( onClick = {
                             navController.navigate(Routes.Profile.route)
                         }) {

--- a/app/src/main/java/com/example/active_portfolio_mobile/ui/profile/ProfilePage.kt
+++ b/app/src/main/java/com/example/active_portfolio_mobile/ui/profile/ProfilePage.kt
@@ -22,10 +22,10 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.Logout
+import androidx.compose.material.icons.filled.Dashboard
 import androidx.compose.material.icons.filled.Edit
 import androidx.compose.material.icons.filled.Email
 import androidx.compose.material.icons.filled.School
-import androidx.compose.material.icons.filled.Work
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.CircularProgressIndicator
@@ -55,6 +55,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.lifecycle.viewmodel.compose.viewModel
 import coil.compose.AsyncImage
+import com.example.active_portfolio_mobile.composables.adventure.AdventureNavigationList
 import com.example.active_portfolio_mobile.layouts.MainLayout
 import com.example.active_portfolio_mobile.ui.auth.AuthViewModel
 import com.example.active_portfolio_mobile.viewModels.UserPortfolio
@@ -269,13 +270,12 @@ fun ProfilePage(
                     Spacer(Modifier.width(4.dp))
                     Text("Edit")
                 }
-
                 OutlinedButton(
                     onClick = {
                     },
                     modifier = Modifier.weight(1f)
                 ) {
-                    Icon(Icons.Default.Work, null, modifier = Modifier.size(16.dp))
+                    Icon(Icons.Default.Dashboard , null, modifier = Modifier.size(16.dp))
                     Spacer(Modifier.width(4.dp))
                     Text("Portfolio", maxLines = 1)
                 }
@@ -356,6 +356,7 @@ fun ProfilePage(
                     Text("Get Portfolio static!!")
                 }
             }
+            AdventureNavigationList(user.id )
         }
     }
 }

--- a/app/src/main/java/com/example/active_portfolio_mobile/viewModels/AdventureCreationUpdateVM.kt
+++ b/app/src/main/java/com/example/active_portfolio_mobile/viewModels/AdventureCreationUpdateVM.kt
@@ -109,13 +109,18 @@ class AdventureCreationUpdateVM : ViewModel() {
      * Creates an Adventure or updates an existing one depending on whether the view model's
      * adventure has a set id. Sets the adventure id once a new Adventure is created so it can
      * proceed to be updated when this function is called again.
+     * @param token the token for authorizing the user creating the adventure. If the token
+     * is null or invalid, there will be an error.
      */
-    fun saveAdventure() {
+    fun saveAdventure(token: String?) {
         viewModelScope.launch {
             try {
                 var response: Response<Adventure>
                 if (adventure.value.id == "") {
-                    response = ActivePortfolioApi.adventure.create(adventure.value)
+                    response = ActivePortfolioApi.adventure.create(
+                        "Bearer $token",
+                        adventure.value
+                    )
                 } else {
                     val updatedAdventure = AdventureUpdateRequest(
                         newTitle = adventure.value.title,
@@ -124,6 +129,7 @@ class AdventureCreationUpdateVM : ViewModel() {
                     )
                     response = ActivePortfolioApi.adventure.update(
                         id = adventure.value.id,
+                        token = "Bearer $token",
                         updatedAdventure = updatedAdventure
                     )
                 }
@@ -145,11 +151,16 @@ class AdventureCreationUpdateVM : ViewModel() {
      * Deletes an adventure through the Active Portfolio API using the current id value of view model's
      * adventure. The values for the view model's held adventure are then reset (except for userId),
      * allowing a new adventure to be defined and created.
+     * @param token the token for authorizing the user deleting the adventure. If the token
+     * is null or invalid, there will be an error.
      */
-    fun deleteAdventure() {
+    fun deleteAdventure(token: String?) {
         viewModelScope.launch {
             try {
-                val response = ActivePortfolioApi.adventure.delete(adventure.value.id)
+                val response = ActivePortfolioApi.adventure.delete(
+                    "Bearer $token",
+                    adventure.value.id
+                )
                 if (response.isSuccessful) {
                     _adventure.update { it.copy(id = "", title = "", visibility = "", portfolios = emptyList()) }
                     _message.value = "Success"

--- a/app/src/main/java/com/example/active_portfolio_mobile/viewModels/AdventureSectionCreationVM.kt
+++ b/app/src/main/java/com/example/active_portfolio_mobile/viewModels/AdventureSectionCreationVM.kt
@@ -50,7 +50,7 @@ class AdventureSectionCreationVM : ViewModel() {
      * The function for saving an adventure section to the database which has a content type which
      * takes a simple string.
      */
-    fun saveNewSection(sectionToSave: AdventureSection, setSuccess: (Boolean) -> Unit) {
+    fun saveNewSection(sectionToSave: AdventureSection, token: String?, setSuccess: (Boolean) -> Unit) {
         viewModelScope.launch{
             try {
                 val request = AdventureSectionCreationRequest(
@@ -62,6 +62,7 @@ class AdventureSectionCreationVM : ViewModel() {
                     type = sectionToSave.type
                 )
                 val response = ActivePortfolioApi.adventureSection.createSection(
+                    "Bearer $token",
                     request
                 )
                 if (response.isSuccessful) {
@@ -84,6 +85,7 @@ class AdventureSectionCreationVM : ViewModel() {
     fun saveNewImageSection(
         sectionToSave: AdventureSection,
         images: List<Bitmap>,
+        token: String?,
         setSuccess: (Boolean) -> Unit
     ) {
         viewModelScope.launch{
@@ -94,6 +96,7 @@ class AdventureSectionCreationVM : ViewModel() {
                     images = images
                 )
                 val response = ActivePortfolioApi.adventureSection.createImageSection(
+                    token = "Bearer $token",
                     label = sectionToSave.label.toRequestBody("text/plain".toMediaType()),
                     description = sectionToSave.label.toRequestBody("text/plain".toMediaType()),
                     type = sectionToSave.type.toRequestBody("text/plain".toMediaType()),

--- a/app/src/main/java/com/example/active_portfolio_mobile/viewModels/AdventureSectionUpdateVM.kt
+++ b/app/src/main/java/com/example/active_portfolio_mobile/viewModels/AdventureSectionUpdateVM.kt
@@ -75,8 +75,9 @@ class AdventureSectionUpdateVM : ViewModel() {
     /**
      * Saves updates to an existing section in the database via the ActivePortfolio API.
      * @param section the updated Adventure Section to be saved.
+     * @param token the authentication token of the signed-in user.
      */
-    fun updateSection(section: AdventureSection, setMessage: (String) -> Unit) {
+    fun updateSection(section: AdventureSection, token: String?, setMessage: (String) -> Unit) {
         viewModelScope.launch {
             try {
                 val updatedSection = AdventureSectionUpdateRequest(
@@ -86,6 +87,7 @@ class AdventureSectionUpdateVM : ViewModel() {
                     newPortfolios = section.portfolios
                 )
                 val response = ActivePortfolioApi.adventureSection.updateSection(
+                    token = "Bearer $token",
                     sectionId = section.id,
                     updatedSection = updatedSection
                 )
@@ -103,11 +105,15 @@ class AdventureSectionUpdateVM : ViewModel() {
     /**
      * Deletes an adventure section through the Active Portfolio API.
      * @param section the adventure section to be deleted.
+     * @param token the authentication token of the signed-in user.
      */
-    fun deleteSection(section: AdventureSection, setMessage: (String) -> Unit) {
+    fun deleteSection(section: AdventureSection, token: String?, setMessage: (String) -> Unit) {
         viewModelScope.launch {
             try {
-                val response = ActivePortfolioApi.adventureSection.delete(section.id)
+                val response = ActivePortfolioApi.adventureSection.delete(
+                    token = "Bearer $token",
+                    section.id
+                )
                 if (response.isSuccessful) {
                    setMessage("Success")
                     sections.value = sections.value.filterNot { it.id == section.id }
@@ -220,9 +226,9 @@ class AdventureSectionImageUpdateVM : ViewModel() {
 
     /**
      * Saves updates to an existing image section in the database via the ActivePortfolio API.
-     * @param section the updated Adventure Section to be saved.
+     * @param token the authentication token of the signed-in user.
      */
-    fun updateSection(setMessage: (String) -> Unit) {
+    fun updateSection(token: String?, setMessage: (String) -> Unit) {
         viewModelScope.launch {
             try {
                 val convertedImages = convertImagesForRequest(
@@ -230,6 +236,7 @@ class AdventureSectionImageUpdateVM : ViewModel() {
                     images = _bitmapImages.value
                 )
                 val response = ActivePortfolioApi.adventureSection.updateImageSection(
+                    token = "Bearer $token",
                     id = _section.value.id,
                     label = _section.value.label.toRequestBody("text/plain".toMediaType()),
                     description = (_section.value.description ?: "").toRequestBody("text/plain".toMediaType()),


### PR DESCRIPTION
The Plus Button on the bottom bar of the main layout now redirects you to the sign-in page if you aren't signed in.

Creation, Update, and Delete requests for Adventures and Sections using retrofit now include the authentication token from the AuthViewModel. This token can be used on the backend for security authentication and authorization.