### PR TITLE
Fix adventure reload user change

### DIFF
--- a/app/src/main/java/com/example/active_portfolio_mobile/composables/adventure/AdvenureNavigationList.kt
+++ b/app/src/main/java/com/example/active_portfolio_mobile/composables/adventure/AdvenureNavigationList.kt
@@ -44,7 +44,7 @@ fun AdventureNavigationList(
     userId: String,
     adventureVM: AdventureVM = viewModel()
 ) {
-    LaunchedEffect(Unit) {
+    LaunchedEffect(userId) {
         adventureVM.fetchAdventuresByUser(userId)
     }
     val adventures = adventureVM.adventures.collectAsStateWithLifecycle()

--- a/app/src/main/java/com/example/active_portfolio_mobile/navigation/Router.kt
+++ b/app/src/main/java/com/example/active_portfolio_mobile/navigation/Router.kt
@@ -42,6 +42,7 @@ import com.example.active_portfolio_mobile.ui.profile.EditProfilePage
 import com.example.active_portfolio_mobile.ui.profile.ProfileViewModel
 import com.example.active_portfolio_mobile.ui.search.SearchResultPage
 import com.example.active_portfolio_mobile.ui.search.SearchViewModel
+import com.example.active_portfolio_mobile.viewModels.AdventureVM
 import com.example.active_portfolio_mobile.viewModels.GetPortfoliosVM
 
 //Sets up the app navigation using NavHost with three routes: LandingPage,
@@ -199,10 +200,12 @@ fun Router(modifier: Modifier) {
                         val profileViewModel: ProfileViewModel = viewModel(
                             factory = ViewModelFactory(tokenManager)
                         )
+                        val adventureVM: AdventureVM = viewModel()
                         ProfilePage(
                             username = null,
                             authViewModel,
                             profileViewModel,
+                            adventureVM = adventureVM,
                             onEditProfile = {
                                 navController.navigate(Routes.EditProfile.route)
                             }
@@ -265,6 +268,9 @@ fun Router(modifier: Modifier) {
                     val query = backStackEntry.arguments?.getString("query") ?: ""
                     SearchResultPage(initialQuery = query, viewModel = searchViewModel)
                 }
+                /**
+                 * OtherUserProfile
+                 */
                 composable(
                     route = Routes.OtherUserProfile.route,
                     arguments = listOf(
@@ -276,11 +282,13 @@ fun Router(modifier: Modifier) {
                     val profileViewModel: ProfileViewModel = viewModel(
                         factory = ViewModelFactory(tokenManager)
                     )
+                    val adventureVM: AdventureVM = viewModel()
                     val username = backStackEntry.arguments?.getString("username") ?: ""
                     ProfilePage(
                         username = username,
                         authViewModel = authViewModel,
                         profileViewModel = profileViewModel,
+                        adventureVM = adventureVM,
                         onEditProfile = {}
                     )
                 }

--- a/app/src/main/java/com/example/active_portfolio_mobile/ui/profile/ProfilePage.kt
+++ b/app/src/main/java/com/example/active_portfolio_mobile/ui/profile/ProfilePage.kt
@@ -60,6 +60,7 @@ import com.example.active_portfolio_mobile.layouts.MainLayout
 import com.example.active_portfolio_mobile.navigation.LocalNavController
 import com.example.active_portfolio_mobile.navigation.Routes
 import com.example.active_portfolio_mobile.ui.auth.AuthViewModel
+import com.example.active_portfolio_mobile.viewModels.AdventureVM
 import com.example.active_portfolio_mobile.viewModels.UserPortfolio
 import kotlinx.coroutines.launch
 
@@ -85,6 +86,7 @@ fun ProfilePage(
     username: String? = null,
     authViewModel: AuthViewModel,
     profileViewModel: ProfileViewModel,
+    adventureVM: AdventureVM,
     onEditProfile: () -> Unit
 ){
     val localContext = LocalContext.current
@@ -379,7 +381,7 @@ fun ProfilePage(
                 }
             }
             // ===== Adventure List =====
-            AdventureNavigationList(user.id)
+            AdventureNavigationList(user.id,adventureVM)
         }
     }
 }


### PR DESCRIPTION
## Problem
When viewing another user's profile, the adventures list displayed the logged-in user's adventures instead of the target user's adventures.

## Solution
- Changed `LaunchedEffect(Unit)` to `LaunchedEffect(userId)` in AdventureNavigationList to trigger reload when userId changes
- Create AdventureVM in Navigation composable and pass it to ProfilePage to maintain a single instance across recompositions

## Changes
- `AdventureNavigationList.kt`: Changed LaunchedEffect key from Unit to userId
- `ProfilePage.kt`: Added adventureVM parameter
- `Router.kt`: Create AdventureVM in Profile and OtherUserProfile routes and pass to ProfilePage
