### PR TITLE
feat: make portfolio button visible to all users

### DIFF
--- a/app/src/main/java/com/example/active_portfolio_mobile/ui/profile/ProfilePage.kt
+++ b/app/src/main/java/com/example/active_portfolio_mobile/ui/profile/ProfilePage.kt
@@ -203,25 +203,26 @@ fun ProfilePage(
                     user.username?.takeIf { it.isNotBlank() }?.let {
                         Text(
                             text = "@$it",
-                            style = MaterialTheme.typography.bodyLarge,
+                            style = MaterialTheme.typography.bodyMedium,
                             color = MaterialTheme.colorScheme.onSurfaceVariant
                         )
                     }
 
                     Surface(
-                        shape = RoundedCornerShape(12.dp),
+                        shape = RoundedCornerShape(50),
                         color = when (user.role) {
-                            "teacher" -> MaterialTheme.colorScheme.primaryContainer
-                            "student" -> MaterialTheme.colorScheme.secondaryContainer
-                            "public" -> MaterialTheme.colorScheme.secondaryContainer
-                            else -> MaterialTheme.colorScheme.tertiaryContainer
+                            "teacher" -> MaterialTheme.colorScheme.tertiaryContainer.copy(alpha = 0.6f)
+                            "student" -> MaterialTheme.colorScheme.secondary.copy(alpha = 0.35f)
+                            "cs_community" -> MaterialTheme.colorScheme.primaryContainer
+                            "public" -> MaterialTheme.colorScheme.surfaceVariant
+                            else -> MaterialTheme.colorScheme.surfaceVariant
                         }
                     ) {
                         Text(
                             text = user.role,
-                            modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
-                            style = MaterialTheme.typography.labelMedium,
-                            color = MaterialTheme.colorScheme.onPrimaryContainer
+                            modifier = Modifier.padding(horizontal = 8.dp, vertical = 3.dp),
+                            style = MaterialTheme.typography.labelSmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant
                         )
                     }
                 }
@@ -267,7 +268,22 @@ fun ProfilePage(
                 }
             }
 
-            // ===== Button =====
+            // ===== Portfolio Button (Public)=====
+            OutlinedButton(
+                onClick = {
+                    navController.navigate(Routes.UserPortfolio.go(user.id))
+                },
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 16.dp),
+                shape = RoundedCornerShape(16.dp)
+            ) {
+                Icon(Icons.Default.Dashboard, null, modifier = Modifier.size(20.dp))
+                Spacer(Modifier.width(8.dp))
+                Text("Portfolio", maxLines = 1)
+            }
+
+            // =====  Edit + Logout Button (only Login user can see)=====
             if (isOwnProfile) {
                 Row(
                     modifier = Modifier
@@ -277,27 +293,20 @@ fun ProfilePage(
                 ) {
                     OutlinedButton(
                         onClick = onEditProfile,
-                        modifier = Modifier.weight(1f)
+                        modifier = Modifier.weight(1f),
+                        shape = RoundedCornerShape(12.dp)
                     ) {
-                        Icon(Icons.Default.Edit, null, modifier = Modifier.size(16.dp))
-                        Spacer(Modifier.width(2.dp))
-                        Text("Edit",fontSize = 12.sp)
+                        Icon(Icons.Default.Edit, null, modifier = Modifier.size(20.dp))
+                        Spacer(Modifier.width(8.dp))
+                        Text("Edit")
                     }
-                    OutlinedButton(
-                        onClick = {
-                            navController.navigate(Routes.UserPortfolio.go(user.id))
-                        },
-                        modifier = Modifier.weight(1f)
-                    ) {
-                        Icon(Icons.Default.Dashboard, null, modifier = Modifier.size(16.dp))
-                        Spacer(Modifier.width(2.dp))
-                        Text("Portfolio", maxLines = 1,fontSize = 12.sp)
-                    }
+
                     OutlinedButton(
                         onClick = {
                             authViewModel.logout()
                         },
                         modifier = Modifier.weight(1f),
+                        shape = RoundedCornerShape(12.dp),
                         colors = ButtonDefaults.outlinedButtonColors(
                             contentColor = MaterialTheme.colorScheme.error
                         )
@@ -305,10 +314,10 @@ fun ProfilePage(
                         Icon(
                             Icons.AutoMirrored.Filled.Logout,
                             null,
-                            modifier = Modifier.size(16.dp)
+                            modifier = Modifier.size(20.dp)
                         )
-                        Spacer(Modifier.width(2.dp))
-                        Text("Logout",fontSize = 12.sp)
+                        Spacer(Modifier.width(8.dp))
+                        Text("Logout")
                     }
                 }
 
@@ -406,13 +415,13 @@ private fun ProfilePicture(
         Box(
             modifier = modifier
                 .clip(CircleShape)
-                .background(MaterialTheme.colorScheme.primary),
+                .background(MaterialTheme.colorScheme.primaryContainer),
             contentAlignment = Alignment.Center
         ) {
             Text(
                 text = firstName.firstOrNull()?.uppercase() ?: "?",
-                style = MaterialTheme.typography.displayLarge,
-                color = MaterialTheme.colorScheme.onPrimary,
+                style = MaterialTheme.typography.displayMedium,
+                color = MaterialTheme.colorScheme.primary,
                 fontWeight = FontWeight.Bold
             )
         }


### PR DESCRIPTION
## Summary
Enable viewing of other users' portfolios and refine ProfilePage UI for better clarity and consistency.

## Problem
The Portfolio button was previously restricted to the logged-in user's own profile, preventing users from exploring other profiles’ portfolios.

## Solution
- Display the Portfolio button for all profile views.
- Restrict Edit/Logout buttons to the profile owner.

## Additional UI Improvements
- Improved role badge color differentiation
- Unified button shapes and icon sizes.